### PR TITLE
Fix for BAT1 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,9 @@ critical at 3% and using dark icons:
 ```
 battmon --interval 2 --delta 3 --low 10 --critical 3 --dark
 ```
+
+### TODO
+[x] Add support for BAT1
+[ ] Add support for custom battery (if not in the proper path)
+[ ] Fix it for dual battery system 
+

--- a/README.md
+++ b/README.md
@@ -64,7 +64,10 @@ battmon --interval 2 --delta 3 --low 10 --critical 3 --dark
 ```
 
 ### TODO
+
 [x] Add support for BAT1
+
 [ ] Add support for custom battery (if not in the proper path)
+
 [ ] Fix it for dual battery system 
 

--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ battmon --interval 2 --delta 3 --low 10 --critical 3 --dark
 
 ### TODO
 
-[x] Add support for BAT1
+- [x] Add support for BAT1
 
-[ ] Add support for custom battery (if not in the proper path)
+- [ ] Add support for custom battery (if not in the proper path)
 
-[ ] Fix it for dual battery system 
+- [ ] Fix it for dual battery system 
 

--- a/battmon.cpp
+++ b/battmon.cpp
@@ -24,7 +24,7 @@
 #include <boost/program_options/parsers.hpp>
 #include <boost/filesystem.hpp>
 
-#define VERSION     "0.5beta2"
+#define VERSION     "0.5beta3"
 
 
 void checkBattery (); // poll function
@@ -156,9 +156,10 @@ void checkBattery ()
     // This basically sets battery variable to a particular value depending upon which one is used.
     // It can be called as a bug/feature but if you have two batteries only battery 1 will be selected
     // next commit will probably fix this!
-    //
+    
     boost::filesystem::exists ( "/sys/class/power_supply/BAT0" ) ? battery = 0 : battery = -1;
     boost::filesystem::exists ( "/sys/class/power_supply/BAT1" ) ? battery = 1 : battery = -1;
+    
     if ( battery == 0 ) 
     {
         capacityfilepath = "/sys/class/power_supply/BAT0/capacity";

--- a/battmon.cpp
+++ b/battmon.cpp
@@ -82,8 +82,7 @@ int main ( const int argc, const char *argv[] )
               "Critical battery threshold in percent (default = 5%)." )
             ( "run-once,r", "Only poll battery state once and exit." )
             ( "dark,k", "Use dark icons instead of the default light ones." )
-            ( "debug", "Print debug comments to STDERR." )
-            ( "bat", "Select battery" );
+            ( "debug", "Print debug comments to STDERR." );
 
     pOpt::variables_map vm;
     pOpt::store ( pOpt::parse_command_line ( argc, argv, desc ), vm );
@@ -156,7 +155,7 @@ void checkBattery ()
 
     // This basically sets battery variable to a particular value depending upon which one is used.
     // It can be called as a bug/feature but if you have two batteries only battery 1 will be selected
-    // next commit will probably fix this
+    // next commit will probably fix this!
     //
     boost::filesystem::exists ( "/sys/class/power_supply/BAT0" ) ? battery = 0 : battery = -1;
     boost::filesystem::exists ( "/sys/class/power_supply/BAT1" ) ? battery = 1 : battery = -1;

--- a/battmon.cpp
+++ b/battmon.cpp
@@ -39,7 +39,10 @@ int ccap;   // current batt capacity percent
 int pcap;   // previous batt capacity percent
 std::string cstat; // current batt status
 std::string pstat; // previous batt status
+std::string capacityfilepath; // path of the file that has capacity 
+std::string statusfilepath; // path of the file that has statistics
 
+int battery; // flag to identify battery
 bool debug;
 bool bat;
 bool cont; // continuous mode or poll once mode
@@ -79,7 +82,8 @@ int main ( const int argc, const char *argv[] )
               "Critical battery threshold in percent (default = 5%)." )
             ( "run-once,r", "Only poll battery state once and exit." )
             ( "dark,k", "Use dark icons instead of the default light ones." )
-            ( "debug", "Print debug comments to STDERR." );
+            ( "debug", "Print debug comments to STDERR." )
+            ( "bat", "Select battery" );
 
     pOpt::variables_map vm;
     pOpt::store ( pOpt::parse_command_line ( argc, argv, desc ), vm );
@@ -132,38 +136,52 @@ int main ( const int argc, const char *argv[] )
 
 void checkBattery ()
 {
-
-    // check if battery is present
-    if ( !boost::filesystem::exists ( "/sys/class/power_supply/BAT0" ) )
+    if (!boost::filesystem::exists ( "/sys/class/power_supply/BAT0" ) && !boost::filesystem::exists ( "/sys/class/power_supply/BAT1" ) )
     {
-
         if ( debug )
-            std::cerr << "\x1b[01mNo battery.\x1b[00m\n";
-
+            std::cerr << "\x1b[01mNo BAT0 and No BAT1.\x1b[00m\n";
         if ( bat )
             // if there previously was a battery, notify that it has been removed
         {
             notify_init ( "battmon" );
             NotifyNotification *Batt;
-            Batt = notify_notification_new ( "No Battery", "No battery present.", BATT_CRIT );
+            Batt = notify_notification_new ( "No Battery!", "No battery present!", BATT_CRIT );
             notify_notification_show ( Batt, NULL );
             g_object_unref ( G_OBJECT( Batt ) );
             notify_uninit ();
         }
-
-
         bat = false;
         return;
     }
 
+    // This basically sets battery variable to a particular value depending upon which one is used.
+    // It can be called as a bug/feature but if you have two batteries only battery 1 will be selected
+    // next commit will probably fix this
+    //
+    boost::filesystem::exists ( "/sys/class/power_supply/BAT0" ) ? battery = 0 : battery = -1;
+    boost::filesystem::exists ( "/sys/class/power_supply/BAT1" ) ? battery = 1 : battery = -1;
+    if ( battery == 0 ) 
+    {
+        capacityfilepath = "/sys/class/power_supply/BAT0/capacity";
+        statusfilepath = "/sys/class/power_supply/BAT0/status";
+    }
+    else if ( battery == 1 ) 
+    {
+        capacityfilepath = "/sys/class/power_supply/BAT1/capacity";
+        statusfilepath = "/sys/class/power_supply/BAT1/status";
+    }
+    else 
+    {
+        std::cerr << "\x1b[01mNo BAT0 or BAT1.\x1b[00m\n";
+    }
     bat = true;
 
     if ( debug )
         std::cerr << "Polling.\n";
-
+    
     // read information from battery capacity and status files
-    std::ifstream capfile ( "/sys/class/power_supply/BAT0/capacity" );
-    std::ifstream statfile ( "/sys/class/power_supply/BAT0/status" );
+    std::ifstream capfile ( capacityfilepath );
+    std::ifstream statfile ( statusfilepath );
     capfile >> ccap;
     statfile >> cstat;
 


### PR DESCRIPTION
Bug: 
There was no support if your system defaulted to have Bat1 instead of BAT0 because it was hard coded inside. 

```
[akuma@shiro battmon]$ ls
battmon.cpp  bin  cmake  CMakeLists.txt  icons  LICENSE  README.md
[akuma@shiro battmon]$ ls /sys/class/power_supply/
ACAD  BAT1
[akuma@shiro battmon]$ battmon --debug
Debug mode.
Polling interval:	5
No battery.
^C
[akuma@shiro battmon]$ 
```
Error was probably because path only checked for BAT0 and not BAT1, so added the support for bat1 in the current patch, also created a todolist. Please change version as per your wish 
*More tests might be needed*